### PR TITLE
各グループの人数の表示

### DIFF
--- a/src/components/Main/Sidebar/Content/MemberGroup.vue
+++ b/src/components/Main/Sidebar/Content/MemberGroup.vue
@@ -3,6 +3,8 @@
     div.member-group-name-container(@click="toggle")
       p
         | {{groupName}}
+        span.member-count(v-if="filterUnread") {{ filteredUnreadMembers.length }}
+        span.member-count(v-else) {{ filteredMembers.length }}
     div.member-group-list(ref="list")
       transition(name="simple" @after-enter="removeHeight" @after-leave="zeroHeight")
         div(ref="listWrap" v-show="isOpen")
@@ -176,6 +178,12 @@ export default {
     color: $text-light-color
     padding:
       left: 10px
+  .member-count
+    padding: 0 0.5rem
+    &::after
+      content: ")"
+    &::before
+      content: "("
 .simple-enter-active
   transition: all .1s
   opacity: 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49056869/56847229-60276380-6913-11e9-9ce7-126904437db7.png)

こんな感じにグループの横に人数を表示します
よろしくお願いします