### PR TITLE
EXIFによる画像回転に対応

### DIFF
--- a/src/components/Main/Modal/Util/ImageViewer.vue
+++ b/src/components/Main/Modal/Util/ImageViewer.vue
@@ -94,4 +94,5 @@ export default {
     size: contain
     repeat: no-repeat
     position: center
+  image-orientation: from-image
 </style>


### PR DESCRIPTION
Chrome、FirefoxでEXIFの画像回転を無視していたのを修正

Chrome81～　Firefox26～

よろしくお願いします